### PR TITLE
Documentando planejamento da sprint

### DIFF
--- a/sprints/sprint1/planejamento.md
+++ b/sprints/sprint1/planejamento.md
@@ -1,1 +1,30 @@
-# Hey
+# Planejamento 
+|Sprint|Inicio|Fim|
+|:--:|:--:|:--:|
+|01|29/08/2021|12/08/2021|
+## Discussão
+No primeiro dia da sprint o grupo se reuniu pela primeira vez. O primeiro passo tomado foi de discutir a familiaridade da equipe com o projeto em questão. Com isso foi notado o primeiro risco mapeado. A maior parte dos membros possuia pouco ou nenhum conhecimento acerca de Kubernetes. Similarmente, a maior parte dos membros também não possuia experiência com a linguagem Go, utilizada amplamente no projeto. Dessa forma, para que fosse possível contribuir, esse risco deveria ser primeiro mitigado. Levando então para a primeira tarefa estipulada, de coletar e estudar materiais da linguagem Go e de Kubernetes.
+
+Também nesse momento foi elicitada a necessidade de criar uma Wiki, na qual seria documentado o progresso da equipe ao longo do semestre. 
+
+Por fim, fizemos o primeiro contato com o coach da equipe, Ricardo Katz. Marcando o primeiro encontro para o dia 5, na semana seguinte.
+
+## Riscos
+
+|ID|Descrição|
+|:--:|:--:|
+|R01|A maior parte da equipe não possuem experiência com a linguagem Go|
+|R02|A maior parte da equipe não possuem experiência com Kubernetes|
+
+## Tarefas
+
+|Issue|Descrição|Responsável|
+|:--:|:--:|:--:|
+|[#1](https://github.com/GCES-Kubernetes/Wiki/issues/1)|Construir wiki destinada a armazenar o progresso na disciplina|Marcos Nery|
+|[#2](https://github.com/GCES-Kubernetes/Wiki/issues/2)|Promover aprendizados acerca da linguagem Go|Todos|
+|[#3](https://github.com/GCES-Kubernetes/Wiki/issues/3)|Promover aprendizados acerca de Kubernetes |Todos|
+
+## Histórico de Revisão
+|Data|Versão|Descrição|Autor|
+|:--:|:--:|:--:|:--:|
+|05/08/21|1.0|Criação da página com o resumo do planejamento|Marcos Nery|


### PR DESCRIPTION
Construindo na Wiki a página destinada a documentação do planejamento da sprint 01. Para manter a transparência e rastreabilidade do planejado. 