### PR TITLE
Documentando aprendizados do Kubernetes Code Summit

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -1,5 +1,8 @@
 - [<b>GCES - Kubernetes</b>](/)
 
 - Sprint 1
-    - [Planejamento](/sprints/sprint1/planejamento.md) 
-    - [Resultados](/sprints/sprint1/resultados.md)
+    - [Planejamento](/sprints/sprint1/planejamento.md)
+    - Resultados 
+        - [Golang](/sprints/sprint1/resultados/Golang.md)
+        - [Kubernetes](/sprints/sprint1/resultados/Kubernetes.md)
+        - [Comunidade](/sprints/sprint1/resultados/Comunidade.md)

--- a/sprints/sprint1/resultados.md
+++ b/sprints/sprint1/resultados.md
@@ -1,1 +1,0 @@
-# Resultados da sprint

--- a/sprints/sprint1/resultados/Comunidade.md
+++ b/sprints/sprint1/resultados/Comunidade.md
@@ -1,0 +1,33 @@
+# Kubernetes Contributor Summit
+A comunidade do Kubernetes é uma das maiores e mais ativas de todo o universo open-source. O projeto é constituido por vários sub projetos e existem ainda vários outros repositórios dedicados a módulos auxiliares ou implementações alternativas.
+Cada um desses sub projetos tem por sí grandes quantidades de demandas e grandes quantidades de contribuidores ativos. Cada um com suas próprias reuniões, processos internos e formas de organização e comunicação.
+
+Dito isso, apesar dos guias de contribuição da comunidade serem muito bons, ainda pode ser um desafio se localizar em meio a isso tudo para começar a contribuir. Uma das formas utilizadas para facilitar esse ingresso é o Kubernetes Contributor Summit. Um evento focado em ajudar interessados de qualquer nível de experiência e conhecimento a fazer parte da comunidade. 
+
+Para ajudar os membros do grupo a se familiarizarem com o contexto, o coach [Ricardo Katz](https://github.com/rikatz), membro ativo da comunidade e mantenedor em alguns repositórios oficiais do Kubernetes, decidiu realizar uma versão do evento conosco. A apresentação no evento original dura cerca de quatro horas. Então dividimos ela em duas partes, a primeira tendo sido realizada no dia 11/08.
+
+### Slides da apresentação
+<a href="https://docs.google.com/presentation/d/1usEbwHMSC8vR7HvbxHJBOj2ISdTkw9rmufQUq7fkIl4/edit?pli=1#slide=id.g58d2f31a59_8_288">
+  <img src="https://i.imgur.com/3csj2hJ.png"/>  
+</a>
+
+### Gravação
+
+## Principais aprendizados
+* Principios e forma de funcionamento da comunidade 
+* Integração com as principais formas de comunicação e planejamento. [Slack](slack.k8s.io), [Discuss](discuss.kubernetes.io) e [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-dev)
+* Divisão dos [SIGs](https://github.com/kubernetes/community/blob/master/sig-list.md). *Special Interest Groups*, que são sub-comunidades, cada uma dedicada a cada um dos módulos que constituem o Kubernetes.
+* Divisão dos [Working Groups](https://github.com/kubernetes/community/blob/master/sig-list.md#working-groups). Partes da comunidade que desenvolvem as aplicações que se encaixam nos contextos de vários SIGs.
+* Funcionamento dos fluxos de contribuição e atribuições de cada um dos papeis dos mantenedores dos projetos nesse ciclo.
+* Sistema de label das issues.
+* Tour pelos repositórios com dicas de por onde começar. Gerando as tarefas descritas a seguir.
+
+## Tarefas geradas
+
+Com os aprendizados e dicas do evento o grupo ganhou mais entendimento acerca da organização da comunidade. Dando origem as seguites tarefas para a sprint 02.
+
+|Issue|Descrição|Responsável|
+|:--:|:--:|:--:|
+|[#10](https://github.com/GCES-Kubernetes/Wiki/issues/10)|Entrar na mailing list e assinar o termo|Todos|
+|[#9](https://github.com/GCES-Kubernetes/Wiki/issues/9)|Escolher um SIG para participar|Todos|
+|[#7](https://github.com/GCES-Kubernetes/Wiki/issues/7)|Definir issues candidatas a serem realizadas na sprint 2|Todos|

--- a/sprints/sprint1/resultados/Golang.md
+++ b/sprints/sprint1/resultados/Golang.md
@@ -1,0 +1,1 @@
+# Aprendizados na linguagem Go

--- a/sprints/sprint1/resultados/Kubernetes.md
+++ b/sprints/sprint1/resultados/Kubernetes.md
@@ -1,0 +1,7 @@
+# Aprendizados em Kubernetes
+
+## Introdução ao Kubernetes com Katz
+
+## Hands on com Bargas
+
+## POC


### PR DESCRIPTION
No dia 11 de Agosto, o coach da equipe Ricardo Katz realizou uma versão adaptada do Kubernetes Code Summit. Um evento focado em ajudar interessados de qualquer nível de experiência a ingressarem na comunidade. Dito isso, se faz necessário documentar os aprendizados do evento na Wiki.

## Issue relacionada
#6 